### PR TITLE
Chore/use repository base

### DIFF
--- a/backend-negosud/DTOs/UtilisateurInputDto.cs
+++ b/backend-negosud/DTOs/UtilisateurInputDto.cs
@@ -12,5 +12,5 @@ public class UtilisateurInputDto
     public string Prenom { get; set; }
     public required string access_token { get; set; }
     
-    public required RoleDto RoleDto { get; set; }
+    public required int RoleId { get; set; }
 }

--- a/backend-negosud/Extentions/DependencyInjectionExtension.cs
+++ b/backend-negosud/Extentions/DependencyInjectionExtension.cs
@@ -1,7 +1,10 @@
+using backend_negosud.DTOs;
 using backend_negosud.Entities;
 using backend_negosud.Repository;
 using backend_negosud.Seeds;
 using backend_negosud.Services;
+using FluentValidation;
+using FluentValidation.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
@@ -25,6 +28,9 @@ public static class DependencyInjectionExtension
     public static void AddRepositories(this WebApplicationBuilder builder)
     {
         builder.Services.AddScoped<IUtilisateurRepository, UtilisateurRepository>();
+        builder.Services.AddScoped<IRoleRepository, RoleRepository>();
+        builder.Services.AddScoped<IStockRepository, StockRepository>();
+        builder.Services.AddScoped<IClientRepository, ClientRepository>();
     }
 
     public static void AddControllers(this WebApplicationBuilder builder)
@@ -35,6 +41,16 @@ public static class DependencyInjectionExtension
     public static void AddServices(this WebApplicationBuilder builder)
     {
         builder.Services.AddScoped<IUtilisateurService, UtilisateurService>();
+        builder.Services.AddScoped<IStockService, StockService>();
+        builder.Services.AddScoped<IJwtService<Client, ClientInputDto, ClientOutputDto>, JwtService<Client, ClientInputDto, ClientOutputDto>>();
+        builder.Services.AddScoped<IAuthService<Client, ClientInputDto, ClientOutputDto>, ClientService>();
+        builder.Services.AddScoped<IJwtService<Utilisateur, UtilisateurInputDto, UtilisateurOutputDto>, JwtService<Utilisateur, UtilisateurInputDto, UtilisateurOutputDto>>();
+        builder.Services.AddScoped<IAuthService<Utilisateur, UtilisateurInputDto, UtilisateurOutputDto>, UtilisateurService>();
+        builder.Services.AddScoped<IHashMotDePasseService, HashMotDePasseService>();
+        builder.Services.AddScoped<IEnvoieEmailService, EnvoieEmailService>();
+        builder.Services.AddScoped<ILogger<Program>, Logger<Program>>();
+        builder.Services.AddValidatorsFromAssemblyContaining<Program>();
+        builder.Services.AddFluentValidationAutoValidation();
     }    
     
     public static void AddSeeder(this WebApplicationBuilder builder)

--- a/backend-negosud/Mapper/AutoMapperProfile.cs
+++ b/backend-negosud/Mapper/AutoMapperProfile.cs
@@ -10,17 +10,23 @@ public class AutoMapperProfile : Profile
     {
         CreateMap<Utilisateur, UtilisateurOutputDto>()
             .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.UtilisateurId))
-            .ForMember(dest => dest.RoleId, opt => opt.MapFrom(src => src.Role.RoleId));
-
+            .ForMember(dest => dest.RoleId, opt => opt.MapFrom(src => src.RoleId));
+        
         CreateMap<UtilisateurInputDto, Utilisateur>()
             .ForMember(dest => dest.AccessToken, opt => opt.MapFrom(src => src.access_token))
-            .ForMember(dest => dest.RoleId, opt => opt.MapFrom(src => src.RoleDto.RoleId))
+            .ForMember(dest => dest.RoleId, opt => opt.MapFrom(src => src.RoleId))
+            .ForMember(dest => dest.Role, opt => opt.Ignore())
             .ForMember(dest => dest.Nom, opt => opt.MapFrom(src => src.Nom))
             .ForMember(dest => dest.Prenom, opt => opt.MapFrom(src => src.Prenom));
+        
+        CreateMap<Utilisateur, UtilisateurInputDto>();
 
+   
         CreateMap<Adresse, AdresseDto>();
+        
         CreateMap<RoleDto, Role>()
             .ForMember(dest => dest.RoleId, opt => opt.MapFrom(src => src.RoleId));
+        
         CreateMap<Role, RoleDto>()
             .ForMember(dest => dest.RoleId, opt => opt.MapFrom(src => src.RoleId));
     }

--- a/backend-negosud/Program.cs
+++ b/backend-negosud/Program.cs
@@ -45,27 +45,6 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     }));
 
-// Services utilisateur
-builder.Services.AddScoped<IJwtService<Utilisateur, UtilisateurInputDto, UtilisateurOutputDto>, JwtService<Utilisateur, UtilisateurInputDto, UtilisateurOutputDto>>();
-builder.Services.AddScoped<IAuthService<Utilisateur, UtilisateurInputDto, UtilisateurOutputDto>, UtilisateurService>();
-
-// Services client
-builder.Services.AddScoped<IJwtService<Client, ClientInputDto, ClientOutputDto>, JwtService<Client, ClientInputDto, ClientOutputDto>>();
-builder.Services.AddScoped<IAuthService<Client, ClientInputDto, ClientOutputDto>, ClientService>();
-builder.Services.AddScoped<IClientRepository, ClientRepository>();
-
-
-// Services Stock
-builder.Services.AddScoped<IStockRepository, StockRepository>();
-builder.Services.AddScoped<IStockService, StockService>();
-
-// Reste des services \
-builder.Services.AddScoped<IHashMotDePasseService, HashMotDePasseService>();
-builder.Services.AddScoped<IEnvoieEmailService, EnvoieEmailService>();
-builder.Services.AddScoped<ILogger<Program>, Logger<Program>>();
-builder.Services.AddValidatorsFromAssemblyContaining<Program>();
-builder.Services.AddFluentValidationAutoValidation();
-
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Configuration.AddEnvironmentVariables();

--- a/backend-negosud/Repository/ClientRepository.cs
+++ b/backend-negosud/Repository/ClientRepository.cs
@@ -6,9 +6,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace backend_negosud.Repository;
 
-public class ClientRepository : IClientRepository
+public class ClientRepository : RepositoryBase<Client>,IClientRepository
 {
-    private readonly PostgresContext _context;
     private readonly IMapper _mapper;
 
     private readonly ILogger<ClientRepository> _logger;
@@ -17,53 +16,11 @@ public class ClientRepository : IClientRepository
         PostgresContext context, 
         IMapper mapper, 
 
-        ILogger<ClientRepository> logger)
+        ILogger<ClientRepository> logger) : base(context)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
-    public async Task<ResponseDataModel<ClientOutputDto>> AddAsync(Client entity, CancellationToken cancellationToken = default)
-    {
-        try 
-        {
-            var client = _mapper.Map<Client>(entity);
-            await _context.Clients.AddAsync(client);
-            await _context.SaveChangesAsync();
-            var clientOutput = _mapper.Map<ClientOutputDto>(client);
-            return new ResponseDataModel<ClientOutputDto>
-            {
-                Success = true,
-                Data = clientOutput
-            };
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Erreur lors de la création du client");
-            throw;
-        }
-    }
-
-    public Task<ResponseDataModel<ClientOutputDto>> GetByIdAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task<ResponseDataModel<List<ClientOutputDto>>> GetAllAsync(CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public async Task UpdateAsync(Client entity, CancellationToken cancellationToken = default)
-    {
-        _context.Update(entity);
-        await _context.SaveChangesAsync(cancellationToken);
-    }
-
-    public Task DeleteAsync(Client entity, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
     }
 
     public async Task<bool> EmailExistsAsync(string email)

--- a/backend-negosud/Repository/Interfaces/IClientRepository.cs
+++ b/backend-negosud/Repository/Interfaces/IClientRepository.cs
@@ -3,7 +3,7 @@ using backend_negosud.Entities;
 
 namespace backend_negosud.Repository;
 
-public interface IClientRepository : IRepositoryBase<Client, ClientOutputDto>
+public interface IClientRepository : IRepositoryBase<Client>
 {
     // TODO faire une interface qui mutualise cette methode
     Task<bool> EmailExistsAsync(string email);

--- a/backend-negosud/Repository/Interfaces/IRepositoryBase.cs
+++ b/backend-negosud/Repository/Interfaces/IRepositoryBase.cs
@@ -3,11 +3,11 @@ using backend_negosud.Models;
 
 namespace backend_negosud.Repository;
 
-public interface IRepositoryBase<TEntity, T> where TEntity : class where T : class
+public interface IRepositoryBase<TEntity> where TEntity : class
 {
-    Task<ResponseDataModel<T>> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
-    Task<ResponseDataModel<T>>  GetByIdAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull;
-    Task<ResponseDataModel<List<T>>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
+    Task<TEntity>  GetByIdAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull;
+    Task<List<TEntity>> GetAllAsync(CancellationToken cancellationToken = default);
     Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
     Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default);
 }

--- a/backend-negosud/Repository/Interfaces/IRoleRepository.cs
+++ b/backend-negosud/Repository/Interfaces/IRoleRepository.cs
@@ -2,7 +2,7 @@ using backend_negosud.Entities;
 
 namespace backend_negosud.Repository;
 
-public interface IStockRepository : IRepositoryBase<Stock>
+public interface IRoleRepository : IRepositoryBase<Role>
 {
     
 }

--- a/backend-negosud/Repository/Interfaces/IUtilisateurRepository.cs
+++ b/backend-negosud/Repository/Interfaces/IUtilisateurRepository.cs
@@ -4,7 +4,7 @@ using backend_negosud.Models;
 
 namespace backend_negosud.Repository;
 
-public interface IUtilisateurRepository : IRepositoryBase<Utilisateur , UtilisateurOutputDto>
+public interface IUtilisateurRepository : IRepositoryBase<Utilisateur>
 {
     /*Task<IResponseDataModel<UtilisateurOutputDto>> CreateAsync(UtilisateurInputDto UtilisateurInputDto);*/
     // TODO faire une interface qui mutualise cette methode

--- a/backend-negosud/Repository/RepositoryBase.cs
+++ b/backend-negosud/Repository/RepositoryBase.cs
@@ -1,66 +1,108 @@
 using backend_negosud.Entities;
 using backend_negosud.Models;
 using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
-namespace backend_negosud.Repository;
-
-public class RepositoryBase<TEntity, T> : IRepositoryBase<TEntity, T> where TEntity : class where T : class
+namespace backend_negosud.Repository
 {
-    protected readonly PostgresContext _context;
+    public class RepositoryBase<TEntity> : IRepositoryBase<TEntity> where TEntity : class
+    {
+        protected readonly PostgresContext _context;
 
-    public RepositoryBase(PostgresContext context)
-    {
-        _context = context;
-    }
-
-public virtual async Task<ResponseDataModel<T>> AddAsync(TEntity entity, CancellationToken cancellationToken = default)
-{
-    _context.Set<TEntity>().Add(entity);
-    await SaveChangesAsync(cancellationToken);
-    return new ResponseDataModel<T>
-    {
-        Data = entity as T
-    };
-}
-    
-    public virtual async Task<ResponseDataModel<List<T>>> GetAllAsync(CancellationToken cancellationToken = default)
-    {
-        var entities = await ListAsync(cancellationToken);
-        return new ResponseDataModel<List<T>>
+        public RepositoryBase(PostgresContext context)
         {
-            Data = entities.Cast<T>().ToList()
-        };
-    }
-
-    public virtual async Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
-    {
-        _context.Set<TEntity>().Update(entity);
-        await SaveChangesAsync(cancellationToken);
-    }
-
-    public virtual async Task<ResponseDataModel<T>> GetByIdAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull
-    {
-        var entity = await _context.FindAsync<TEntity>(new object[] { id }, cancellationToken);
-        return new ResponseDataModel<T>
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+        
+        public virtual async Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default)
         {
-            Data = entity as T
-        };
-    }
-    
-    public virtual async Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default)
-    {
-        _context.Set<TEntity>().Remove(entity);
-        await SaveChangesAsync(cancellationToken);
-    }
-
-    protected async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-    {
-        return await _context.SaveChangesAsync(cancellationToken);
-    }
-
-
-    public virtual async Task<List<TEntity>> ListAsync(CancellationToken cancellationToken = default)
-    {
-        return await _context.Set<TEntity>().ToListAsync(cancellationToken);
+            try
+            {
+                _context.Set<TEntity>().Add(entity);
+                await SaveChangesAsync(cancellationToken);
+                return entity;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error adding entity.", ex);
+            }
+        }
+        
+        public virtual async Task<List<TEntity>> GetAllAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _context.Set<TEntity>().ToListAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error retrieving entities.", ex);
+            }
+        }
+        
+        public virtual async Task UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                _context.Set<TEntity>().Update(entity);
+                await SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error updating entity.", ex);
+            }
+        }
+        
+        public virtual async Task<TEntity?> GetByIdAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull
+        {
+            try
+            {
+                return await _context.FindAsync<TEntity>([id], cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Error retrieving entity with ID {id}.", ex);
+            }
+        }
+        
+        public virtual async Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                _context.Set<TEntity>().Remove(entity);
+                await SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error deleting entity.", ex);
+            }
+        }
+        
+        protected async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _context.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error saving changes to the database.", ex);
+            }
+        }
+        
+        public virtual async Task<List<TEntity>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await _context.Set<TEntity>().ToListAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error listing entities.", ex);
+            }
+        }
     }
 }

--- a/backend-negosud/Repository/RoleRepository.cs
+++ b/backend-negosud/Repository/RoleRepository.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using backend_negosud.Entities;
+
+namespace backend_negosud.Repository;
+
+public class RoleRepository : RepositoryBase<Role>, IRoleRepository
+{
+    private readonly IMapper _mapper;
+    private readonly ILogger<RoleRepository> _logger;
+
+    public RoleRepository(PostgresContext context, ILogger<RoleRepository> logger, IMapper mapper) : base(context)
+    {
+        _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+}

--- a/backend-negosud/Repository/StockRepository.cs
+++ b/backend-negosud/Repository/StockRepository.cs
@@ -4,63 +4,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace backend_negosud.Repository;
 
-public class StockRepository : IStockRepository
+public class StockRepository : RepositoryBase<Stock>, IStockRepository
 {
-    protected readonly PostgresContext _context;
 
-    public StockRepository(PostgresContext context)
+    public StockRepository(PostgresContext context) : base(context)
     {
-        _context = context;
     }
-
-    public async Task<ResponseDataModel<Stock>> AddAsync(Stock entity, CancellationToken cancellationToken = default)
-    {
-        _context.Set<Stock>().Add(entity);
-        await SaveChangesAsync(cancellationToken);
-        return new ResponseDataModel<Stock>
-        {
-            Data = entity
-        };
-    }
-
-    public async Task<ResponseDataModel<Stock>> GetByIdAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull
-    {
-        var entity = await _context.FindAsync<Stock>(new object[] { id }, cancellationToken);
-        return new ResponseDataModel<Stock>
-        {
-            Data = entity
-        };
-    }
-
-    public async Task<ResponseDataModel<List<Stock>>> GetAllAsync(CancellationToken cancellationToken = default)
-    {
-        var entities = await ListAsync(cancellationToken);
-        return new ResponseDataModel<List<Stock>>
-        {
-            Data = entities
-        };
-    }
-
-    public async Task UpdateAsync(Stock entity, CancellationToken cancellationToken = default)
-    {
-        var existingEntity = await _context.FindAsync<Stock>(new object[] { entity.StockId }, cancellationToken);
-        _context.Entry(existingEntity).CurrentValues.SetValues(entity);
-        await SaveChangesAsync(cancellationToken);
-    }
-
-    public async Task DeleteAsync(Stock entity, CancellationToken cancellationToken = default)
-    {
-        _context.Set<Stock>().Remove(entity);
-        await SaveChangesAsync(cancellationToken);
-    }
-
-    protected async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
-    {
-        return await _context.SaveChangesAsync(cancellationToken);
-    }
-
-    public virtual async Task<List<Stock>> ListAsync(CancellationToken cancellationToken = default)
-    {
-        return await _context.Set<Stock>().ToListAsync(cancellationToken);
-    }
+    
 }

--- a/backend-negosud/Repository/UtilisateurRepository.cs
+++ b/backend-negosud/Repository/UtilisateurRepository.cs
@@ -7,9 +7,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace backend_negosud.Repository;
 
-public class UtilisateurRepository : IUtilisateurRepository
+public class UtilisateurRepository : RepositoryBase<Utilisateur>, IUtilisateurRepository
 {
-    private readonly PostgresContext _context;
     private readonly IMapper _mapper;
 
     private readonly ILogger<UtilisateurRepository> _logger;
@@ -17,10 +16,8 @@ public class UtilisateurRepository : IUtilisateurRepository
     public UtilisateurRepository(
         PostgresContext context, 
         IMapper mapper, 
-
-        ILogger<UtilisateurRepository> logger)
+        ILogger<UtilisateurRepository> logger):base(context)
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/backend-negosud/Services/JwtService.cs
+++ b/backend-negosud/Services/JwtService.cs
@@ -74,7 +74,7 @@ public string GenererToken(TInputDto inputDto)
         {
             var entity = _mapper.Map<TEntity>(inputDto);
 
-            using var rsa = LoadOrCreateRsaKey();
+            RSA rsa = LoadOrCreateRsaKey();
             var key = new RsaSecurityKey(rsa);
             var credentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256);
 


### PR DESCRIPTION
- Les classes repository héritent bien de RepositoryBase pour utiliser les fonctions de bases... ça évite la duplication des méthodes primaires et de ne pas utiliser la classe qui servait à ça ! 
- Correction et fix des fonctions pour les adapter à cette nouvelle structure