### PR TITLE
- Ajout d'une notion d'expiration du panier.

### DIFF
--- a/backend-negosud/Context/PostgresContext.cs
+++ b/backend-negosud/Context/PostgresContext.cs
@@ -198,7 +198,10 @@ public partial class PostgresContext : DbContext
             entity.Property(e => e.ClientId).HasColumnName("client_id");
             entity.Property(e => e.DateCreation)
                 .HasColumnType("timestamp with time zone")
-                .HasColumnName("date_creation");
+                .HasColumnName("date_creation");            
+            entity.Property(e => e.ExpirationDate)
+                .HasColumnType("timestamp with time zone")
+                .HasColumnName("date_expiration");
             entity.Property(e => e.FactureId).HasColumnName("facture_id");
             entity.Property(e => e.LivraisonId).HasColumnName("livraison_id");
             entity.Property(e => e.Valide).HasColumnName("valide");

--- a/backend-negosud/Controllers/PanierController.cs
+++ b/backend-negosud/Controllers/PanierController.cs
@@ -15,6 +15,17 @@ public class PanierController : ControllerBase
         _panierService = panierService;
     }
     
+    /// <summary>
+    /// Il faut fournir un au minimum : un id d'un client
+    /// </summary>
+    /// <returns>Le panier du client</returns>
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetBasketClient(int id)
+    {
+        var result = await _panierService.GetBasketByClientId(id);
+        return result.Success ? Ok(result) : BadRequest(result);
+    }
+    
     // POST: api/panier
     /// <summary>
     /// Il faut fournir un au minimum : un id d'un client, un id d'un article, une quantité 
@@ -38,6 +49,19 @@ public class PanierController : ControllerBase
         var result = await _panierService.UpdatePanier(panierInputDto);
         return result.Success ? Ok(result) : BadRequest(result);
     }
+    
+    // PUT: api/panier
+    /// <summary>
+    /// Il faut fournir un au minimum : l'id du client.
+    /// </summary>
+    /// <returns>Le panier modifié</returns>
+    [HttpPut("extend/{id}")]
+    public async Task<IActionResult> ExtendBasketDuration(int id)
+    {
+        var result = await _panierService.ExtendDurationBasket(id);
+        return result.Success ? Ok(result) : BadRequest(result);
+    }
+
     
     // DELETE: api/panier/{id}
     /// <summary>

--- a/backend-negosud/DTOs/Commande-client/Outputs/PanierOutputDto.cs
+++ b/backend-negosud/DTOs/Commande-client/Outputs/PanierOutputDto.cs
@@ -4,6 +4,7 @@ public class PanierOutputDto
 {
     public int CommandeId { get; set; }
     public DateTime DateCreation { get; set; }
+    public DateTime ExpirationDate { get; set; }
     public bool Valide { get; set; }
     public int ClientId { get; set; }
     public List<LigneCommandeOutputDto> LigneCommandes { get; set; } = new List<LigneCommandeOutputDto>();

--- a/backend-negosud/Entities/Commande.cs
+++ b/backend-negosud/Entities/Commande.cs
@@ -8,6 +8,7 @@ public partial class Commande
     public int CommandeId { get; set; }
 
     public DateTime DateCreation { get; set; }
+    public DateTime ExpirationDate { get; set; } 
 
     public bool Valide { get; set; }
 

--- a/backend-negosud/Extentions/HangFireExtension.cs
+++ b/backend-negosud/Extentions/HangFireExtension.cs
@@ -1,0 +1,40 @@
+using backend_negosud.Entities;
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+
+namespace backend_negosud.Extentions;
+
+public static class HangFireExtension
+{
+    public static void UseHangfire(this WebApplication app)
+    {
+        app.UseHangfireDashboard();
+        app.UseHangfireServer();
+
+        // tâche récurrente pour nettoyer les paniers expirés
+        using (var serviceScope = app.Services.CreateScope())
+        {
+            var recurringJobManager = serviceScope.ServiceProvider.GetRequiredService<IRecurringJobManager>();
+            recurringJobManager.AddOrUpdate(
+                "cleanup-expired-baskets",
+                () => CleanupExpiredBaskets(serviceScope.ServiceProvider),
+                "*/30 * * * *"); // Exéc toutes les 30 minutes
+        }
+    }
+
+    public static async Task CleanupExpiredBaskets(IServiceProvider serviceProvider)
+    {
+        using (var scope = serviceProvider.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<PostgresContext>();
+            var currentDate = DateTime.UtcNow;
+
+            var expiredBaskets = await context.Commandes
+                .Where(c => !c.Valide && c.ExpirationDate < currentDate)
+                .ToListAsync();
+
+            context.Commandes.RemoveRange(expiredBaskets);
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/backend-negosud/Migrations/PostgresContextModelSnapshot.cs
+++ b/backend-negosud/Migrations/PostgresContextModelSnapshot.cs
@@ -240,6 +240,10 @@ namespace backend_negosud.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("date_creation");
 
+                    b.Property<DateTime>("ExpirationDate")
+                        .HasColumnType("timestamp with time zone")
+                        .HasColumnName("date_expiration");
+
                     b.Property<int?>("FactureId")
                         .HasColumnType("integer")
                         .HasColumnName("facture_id");

--- a/backend-negosud/Program.cs
+++ b/backend-negosud/Program.cs
@@ -110,7 +110,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
+app.UseHangfire(); 
 app.UseRouting();
 app.UseCors("AllowAll");
 app.UseHttpsRedirection();

--- a/backend-negosud/Repository/CommandeRepository.cs
+++ b/backend-negosud/Repository/CommandeRepository.cs
@@ -32,4 +32,15 @@ public class CommandeRepository : RepositoryBase<Commande> , ICommandeRepository
         return await _context.Commandes.Include(c => c.LigneCommandes).ThenInclude(l => l.Article).FirstOrDefaultAsync(c => c.CommandeId == id);
     }
 
+    public async Task<Commande> GetActiveBasketByClientIdAsync(int clientId)
+    {
+        return await _context.Commandes
+            .Where(c => c.ClientId == clientId && !c.Valide)
+            .Include(c => c.LigneCommandes)
+            .ThenInclude(l => l.Article)
+            .OrderByDescending(c => c.DateCreation)
+            .FirstOrDefaultAsync();
+    }
+
+    
 }

--- a/backend-negosud/Repository/Interfaces/ICommandeRepository.cs
+++ b/backend-negosud/Repository/Interfaces/ICommandeRepository.cs
@@ -6,4 +6,6 @@ public interface ICommandeRepository : IRepositoryBase<Commande>
 {
     Task<List<Commande>> GetAllCommandeAsync();
     Task<Commande> GetByIdAndLigneCommandesAsync(int id);
+    // Task<Commande> GetBasketById(int id);
+    Task<Commande> GetActiveBasketByClientIdAsync(int id);
 }

--- a/backend-negosud/Repository/RepositoryBase.cs
+++ b/backend-negosud/Repository/RepositoryBase.cs
@@ -1,11 +1,6 @@
 using backend_negosud.Entities;
-using backend_negosud.Models;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace backend_negosud.Repository
 {

--- a/backend-negosud/Services/Interfaces/IPanierService.cs
+++ b/backend-negosud/Services/Interfaces/IPanierService.cs
@@ -10,4 +10,6 @@ public interface IPanierService
     Task<IResponseDataModel<PanierOutputDto>> UpdatePanier(PanierUpdateInputDto panierInputDto);
 
     Task<IResponseDataModel<string>> DeletePanier(int id);
+    Task<IResponseDataModel<PanierOutputDto>> GetBasketByClientId(int id);
+    Task<IResponseDataModel<string>> ExtendDurationBasket(int id);
 }

--- a/backend-negosud/backend-negosud.csproj
+++ b/backend-negosud/backend-negosud.csproj
@@ -17,6 +17,8 @@
         <PackageReference Include="FluentValidation" Version="11.11.0" />
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+        <PackageReference Include="Hangfire" Version="1.8.17" />
+        <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
         <PackageReference Include="Mailjet.Api" Version="3.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />


### PR DESCRIPTION
- L'expiration est configuré à une heure
- Ajout de la bibliothèque HangFire pour gérer en tâche de fond la suppression et la vérification de l'expiration de chaque panier toutes les 30 minutes.
- Le panier est supprimer après 30 min sans action de la part de l'utilisateur (pas d'update, ni d'extend)
- Modification de la méthode CreatePanier et UpdatePanier qui désormais ajout une heure à la colonne expiration_date
- Ajout de l'attribut expiration_date dans le modèle commande
- Ajout d'une migration pour ajouter cette colonne à la table Commande